### PR TITLE
Fix byte range

### DIFF
--- a/src/com/netease/pomelo/Protocol.java
+++ b/src/com/netease/pomelo/Protocol.java
@@ -27,7 +27,7 @@ public class Protocol {
 	private static String bt2Str(byte[] arr, int start, int end) {
 		StringBuffer buff = new StringBuffer();
 		for (int i = start; i < arr.length && i < end; i++) {
-			buff.append(String.valueOf(Character.toChars(arr[i])));
+			buff.append(String.valueOf(Character.toChars((arr[i]+0xFF) % 0xFF)));
 		}
 		return buff.toString();
 	}


### PR DESCRIPTION
in situations like encode(141, "xxx", msg), bt2Str will raise exception since the code tries Character.toChars(-115)
